### PR TITLE
Switching to use K8s builds from sig-testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ compile:
     - echo "hyperkube_checksums:" >> kubespray.env
     - echo "  $ARCH:" >> kubespray.env
     - echo "  $ARCH:" >> kubespray.env
-    - echo "      $RELEASE: $(sha256sum $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
+    - echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
 
     
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,6 +153,7 @@ container:
     #Publish k8s-dns-node-cache/arm64 image
     - git clone https://github.com/kubernetes/dns.git
     - cd dns
+    - pwd && sleep 10000000
     - make all, build CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" IMAGES="" ARCH="$ARCH" 
     - cd -
     - echo export KUBERNETES_VERSION="$KUBE_DOCKER_IMAGE_TAG" >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,6 +149,7 @@ container:
     #Publish k8s-dns-node-cache/arm64 image
     - git clone https://github.com/kubernetes/dns.git
     - cd dns
+    - sed -i "15s|.*|FROM ARG_FROM|" ./Dockerfile.node-cache
     - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" ARCH="$ARCH" 
     - docker push crosscloudci/k8s-dns-node-cache-"$ARCH:$(git describe --tags --always --dirty)"
     - DNS_GIT_VERSION="$(git describe --tags --always --dirty)"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ compile:
         echo 'Default to amd64 (Intel)'
         echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kubelet >> release.env
         echo export HYPERKUBE_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/hyperkube >> release.env
-        echo export HYPERKUBE_SHA256="$(sha256 "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/hyperkube)" >> release.env
+        echo export HYPERKUBE_SHA256="$(sha256sum "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/hyperkube)" >> release.env
         echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-apiserver >> release.env
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,12 +131,10 @@ container:
     - docker tag "$KUBE_DOCKER_REGISTRY/kube-controller-manager-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-controller-manager:$KUBE_DOCKER_IMAGE_TAG" 
     - docker tag "$KUBE_DOCKER_REGISTRY/kube-scheduler-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-scheduler:$KUBE_DOCKER_IMAGE_TAG"
     - docker tag "$KUBE_DOCKER_REGISTRY/kube-proxy-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
-    - docker tag "$KUBE_DOCKER_REGISTRY/cloud-controller-manager-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/cloud-controller-manager:$KUBE_DOCKER_IMAGE_TAG"
     - docker push "$KUBE_DOCKER_REGISTRY/kube-apiserver:$KUBE_DOCKER_IMAGE_TAG"
     - docker push "$KUBE_DOCKER_REGISTRY/kube-controller-manager:$KUBE_DOCKER_IMAGE_TAG"
     - docker push "$KUBE_DOCKER_REGISTRY/kube-scheduler:$KUBE_DOCKER_IMAGE_TAG"
     - docker push "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
-    - docker push "$KUBE_DOCKER_REGISTRY/cloud-controller-manager:$KUBE_DOCKER_IMAGE_TAG"
     #Publish pause image
     - make -C ./build/pause/ all-push REGISTRY="${KUBE_DOCKER_REGISTRY}"
     #Push dummy coredns image
@@ -175,8 +173,6 @@ container:
     - echo export KUBE_SCHEDULER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export KUBE_PROXY_IMAGE="$KUBE_DOCKER_REGISTRY/kube-proxy" >> release.env
     - echo export KUBE_PROXY_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export CLOUD_CONTROLLER_IMAGE="$KUBE_DOCKER_REGISTRY/cloud-controller-manager" >> release.env
-    - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
     - echo export KUBERNETES_SHA="${CI_COMMIT_SHA}" >> release.env
     - >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,6 +146,12 @@ container:
     - docker pull coredns/coredns:1.3.1
     - docker tag coredns/coredns:1.3.1 crosscloudci/coredns:1.3.1
     - docker push crosscloudci/coredns:1.3.1
+    #Enable binfmt_misc 
+    - >
+      if [ "$ARCH" == "arm64" ]; then
+        echo 'ARCH set to arm64'
+        docker run --privileged linuxkit/binfmt:v0.6
+      fi
     #Publish k8s-dns-node-cache/arm64 image
     - git clone https://github.com/kubernetes/dns.git
     - cd dns

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ compile:
         echo 'ARCH set to arm64'
         echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kubelet >> release.env
         echo export HYPERKUBE_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/hyperkube >> release.env
-        echo export HYPERKUBE_SHA256="$(sha256 "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/hyperkube)" >> release.env
+        echo export HYPERKUBE_SHA256="$(sha256sum "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/hyperkube)" >> release.env
         echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-apiserver >> release.env
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-scheduler >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,11 @@ container:
     - docker pull coredns/coredns:1.3.1
     - docker tag coredns/coredns:1.3.1 crosscloudci/coredns:1.3.1
     - docker push crosscloudci/coredns:1.3.1
+    #Publish k8s-dns-node-cache/arm64 image
+    - git clone https://github.com/kubernetes/dns.git
+    - cd dns
+    - make all, build CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" IMAGES="" ARCH="$ARCH" 
+    - cd -
     - echo export KUBERNETES_VERSION="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export KUBE_APISERVER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-apiserver" >> release.env
     - echo export KUBE_APISERVER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ before_script:
     else
       export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi
-  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+  # - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
   image: crosscloudci/debian-docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,12 +54,16 @@ compile:
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'
         echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kubelet >> release.env
+        echo export HYPERKUBE_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/hyperkube >> release.env
+        echo export HYPERKUBE_SHA256="$(sha256 "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/hyperkube)" >> release.env
         echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-apiserver >> release.env
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-scheduler >> release.env
       else
         echo 'Default to amd64 (Intel)'
         echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kubelet >> release.env
+        echo export HYPERKUBE_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/hyperkube >> release.env
+        echo export HYPERKUBE_SHA256="$(sha256 "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/hyperkube)" >> release.env
         echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-apiserver >> release.env
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,6 +153,7 @@ container:
     #Publish k8s-dns-node-cache/arm64 image
     - git clone https://github.com/kubernetes/dns.git
     - cd dns
+    - sleep 10000000
     - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" ARCH="$ARCH" 
     - docker push crosscloudci/k8s-dns-node-cache-"$ARCH:$(git describe --tags --always --dirty)"
     - echo export DNS_NODE_CACHE_IMAGE="$KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,14 +84,10 @@ container:
   script:
     - apt update
     - apt install -y tar rsync git curl make file net-tools xz-utils
-    # Determine release
-    - >
-      if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
-         RELEASE=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt | cut -f1 -d"-")
-      else
-         RELEASE=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-      fi
-    - RELEASE_STABLE=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+    # Set Kubespray Release
+    - RELEASE_STABLE="v1.15.0"
+    # Determine actual release
+    - RELEASE="$(git describe --tags --always --dirty | cut -f1 -d"-")"
     - export KUBE_DOCKER_REGISTRY="$DOCKER_REGISTRY"
     - export KUBE_DOCKER_IMAGE_TAG="${RELEASE}-${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
@@ -155,12 +151,14 @@ container:
     - cd dns
     - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" ARCH="$ARCH" 
     - docker push crosscloudci/k8s-dns-node-cache-"$ARCH:$(git describe --tags --always --dirty)"
+    - DNS_GIT_VERSION="$(git describe --tags --always --dirty)"
+    - cd -
     - echo export DNS_NODE_CACHE_IMAGE="$KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> release.env
-    - echo export DNS_NODE_CACHE_TAG="$(git describe --tags --always --dirty)" >> release.env
+    - echo export DNS_NODE_CACHE_TAG="$DNS_GIT_VERSION" >> release.env
     - >
       echo "nodelocaldns_image_repo: $KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> kubespray.env
-      echo "nodelocaldns_image_tag: $(git describe --tags --always --dirty)" >> kubespray.env
-    - cd -
+    - >
+      echo "nodelocaldns_image_tag: $DNS_GIT_VERSION" >> kubespray.env
     - echo export KUBERNETES_VERSION="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export KUBE_APISERVER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-apiserver" >> release.env
     - echo export KUBE_APISERVER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,7 +166,7 @@ container:
     - >
       echo "  $ARCH:" >> kubespray.env
     - >
-      echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
+      echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube | awk '{ print $1 }')" >> kubespray.env
     - >
       echo "kube_version: $RELEASE" >> kubespray.env
     - >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ compile:
       - _output/dockerized/bin/linux/
 
 container:
-  image: crosscloudci/debian-docker
+  image: crosscloudci/debian-docker-go
   stage: Package
   dependencies: 
     - compile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,8 +153,7 @@ container:
     #Publish k8s-dns-node-cache/arm64 image
     - git clone https://github.com/kubernetes/dns.git
     - cd dns
-    - pwd && sleep 10000000
-    - make all, build CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" IMAGES="" ARCH="$ARCH" 
+    - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" IMAGES="" ARCH="$ARCH" 
     - cd -
     - echo export KUBERNETES_VERSION="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export KUBE_APISERVER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-apiserver" >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,17 +65,7 @@ compile:
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
       fi
     - >
-      echo "kube_version: $RELEASE" >> kubespray.env
-    - >
       echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
-    - >
-      echo "hyperkube_checksums:" >> kubespray.env
-    - >
-      echo "  $ARCH:" >> kubespray.env
-    - >
-      echo "  $ARCH:" >> kubespray.env
-    - >
-      echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
 
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
@@ -171,6 +161,14 @@ container:
     - echo export CLOUD_CONTROLLER_IMAGE="$KUBE_DOCKER_REGISTRY/cloud-controller-manager" >> release.env
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
+    - >
+      echo "hyperkube_checksums:" >> kubespray.env
+    - >
+      echo "  $ARCH:" >> kubespray.env
+    - >
+      echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
+    - >
+      echo "kube_version: $RELEASE" >> kubespray.env
     - >
       echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
     - >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,13 @@ container:
     #Publish k8s-dns-node-cache/arm64 image
     - git clone https://github.com/kubernetes/dns.git
     - cd dns
-    - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" IMAGES="" ARCH="$ARCH" 
+    - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" ARCH="$ARCH" 
+    - docker push crosscloudci/k8s-dns-node-cache-"$ARCH:$(git describe --tags --always --dirty)"
+    - echo export DNS_NODE_CACHE_IMAGE="$KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> release.env
+    - echo export DNS_NODE_CACHE_TAG="$(git describe --tags --always --dirty)" >> release.env
+    - >
+      echo "nodelocaldns_image_repo: $KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> kubespray.env
+      echo "nodelocaldns_image_tag: $(git describe --tags --always --dirty)" >> kubespray.env
     - cd -
     - echo export KUBERNETES_VERSION="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export KUBE_APISERVER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-apiserver" >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,20 +54,23 @@ compile:
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'
         echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kubelet >> release.env
-        echo export HYPERKUBE_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/hyperkube >> release.env
-        echo export HYPERKUBE_SHA256="$(sha256sum "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/hyperkube)" >> release.env
         echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-apiserver >> release.env
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-scheduler >> release.env
       else
         echo 'Default to amd64 (Intel)'
         echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kubelet >> release.env
-        echo export HYPERKUBE_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/hyperkube >> release.env
-        echo export HYPERKUBE_SHA256="$(sha256sum "$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/hyperkube)" >> release.env
         echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-apiserver >> release.env
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
       fi
+    - echo "kube_version: $RELEASE" >> kubespray.env
+    - echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
+    - echo "hyperkube_checksums:" >> kubespray.env
+    - echo "  $ARCH:" >> kubespray.env
+    - echo "  $ARCH:" >> kubespray.env
+    - echo "      $RELEASE: $(sha256sum $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
+
     
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
@@ -75,6 +78,7 @@ compile:
     expire_in: 1 weeks
     paths:
       - release.env
+      - kubespray.env
       - _output/dockerized/bin/linux/
 
 container:
@@ -162,13 +166,17 @@ container:
     - echo export CLOUD_CONTROLLER_IMAGE="$KUBE_DOCKER_REGISTRY/cloud-controller-manager" >> release.env
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
+    - echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
+    - echo "kube_image_version: $KUBE_DOCKER_IMAGE_TAG" >> kubespray.env 
     - cat release.env
+    - cat kubespray.env
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
     when: always
     expire_in: 1 weeks
     paths:
       - release.env
+      - kubespray.env
 
 Dashboard:
   image: crosscloudci/debian-go

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ before_script:
        echo "Kubernetes pipeline must be created by the trigger client, exiting."
        exit 1
     else
-       source /opt/local/.env ; ./bin/update_dashboard ; popd
+       source /opt/local/.env
     fi
   - ./bin/update_dashboard ; popd
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,6 +91,7 @@ container:
       else
          RELEASE=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
       fi
+    - RELEASE_STABLE=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
     - export KUBE_DOCKER_REGISTRY="$DOCKER_REGISTRY"
     - export KUBE_DOCKER_IMAGE_TAG="${RELEASE}-${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
@@ -166,9 +167,9 @@ container:
     - >
       echo "  $ARCH:" >> kubespray.env
     - >
-      echo "    $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube | awk '{ print $1 }')" >> kubespray.env
+      echo "    $RELEASE_STABLE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube | awk '{ print $1 }')" >> kubespray.env
     - >
-      echo "kube_version: $RELEASE" >> kubespray.env
+      echo "kube_version: $RELEASE_STABLE" >> kubespray.env
     - >
       echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
     - >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,12 +64,13 @@ compile:
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
       fi
-    # - echo "kube_version: $RELEASE" >> kubespray.env
-    # - echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
-    # - echo "hyperkube_checksums:" >> kubespray.env
-    # - echo "  $ARCH:" >> kubespray.env
-    # - echo "  $ARCH:" >> kubespray.env
-    # - echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
+    - >
+      echo "kube_version: $RELEASE" >> kubespray.env
+      echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
+      echo "hyperkube_checksums:" >> kubespray.env
+      echo "  $ARCH:" >> kubespray.env
+      echo "  $ARCH:" >> kubespray.env
+      echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
 
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
@@ -165,8 +166,9 @@ container:
     - echo export CLOUD_CONTROLLER_IMAGE="$KUBE_DOCKER_REGISTRY/cloud-controller-manager" >> release.env
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
-    - echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
-    - echo "kube_image_version: $KUBE_DOCKER_IMAGE_TAG" >> kubespray.env 
+    - >
+      echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
+      echo "kube_image_version: $KUBE_DOCKER_IMAGE_TAG" >> kubespray.env 
     - cat release.env
     - cat kubespray.env
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,6 +162,7 @@ container:
     - echo export CLOUD_CONTROLLER_IMAGE="$KUBE_DOCKER_REGISTRY/cloud-controller-manager" >> release.env
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
+    - echo export KUBERNETES_SHA="${CI_COMMIT_SHA}" >> release.env
     - >
       echo "hyperkube_checksums:" >> kubespray.env
     - >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,7 @@ container:
     - docker push "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
     - docker push "$KUBE_DOCKER_REGISTRY/cloud-controller-manager:$KUBE_DOCKER_IMAGE_TAG"
     #Publish pause image
-    - make -C ./build/pause/ all-push REGISTRY="${KUBE_DOCKER_REGISTRY}"
+    # - make -C ./build/pause/ all-push REGISTRY="${KUBE_DOCKER_REGISTRY}"
     #Push dummy coredns image
     - docker pull coredns/coredns:1.2.6
     - docker tag coredns/coredns:1.2.6 crosscloudci/coredns:1.2.6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,7 +166,7 @@ container:
     - >
       echo "  $ARCH:" >> kubespray.env
     - >
-      echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube | awk '{ print $1 }')" >> kubespray.env
+      echo "    $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube | awk '{ print $1 }')" >> kubespray.env
     - >
       echo "kube_version: $RELEASE" >> kubespray.env
     - >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ compile:
       - _output/dockerized/bin/linux/
 
 container:
-  image: crosscloudci/debian-docker-go
+  image: crosscloudci/debian-docker
   stage: Package
   dependencies: 
     - compile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ container:
     - compile
   script:
     - apt update
-    - apt install -y tar rsync git curl make file net-tools
+    - apt install -y tar rsync git curl make file net-tools xz-utils
     # Determine release
     - >
       if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
@@ -142,7 +142,7 @@ container:
     - docker push "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
     - docker push "$KUBE_DOCKER_REGISTRY/cloud-controller-manager:$KUBE_DOCKER_IMAGE_TAG"
     #Publish pause image
-    # - make -C ./build/pause/ all-push REGISTRY="${KUBE_DOCKER_REGISTRY}"
+    - make -C ./build/pause/ all-push REGISTRY="${KUBE_DOCKER_REGISTRY}"
     #Push dummy coredns image
     - docker pull coredns/coredns:1.2.6
     - docker tag coredns/coredns:1.2.6 crosscloudci/coredns:1.2.6
@@ -153,7 +153,6 @@ container:
     #Publish k8s-dns-node-cache/arm64 image
     - git clone https://github.com/kubernetes/dns.git
     - cd dns
-    - sleep 10000000
     - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" ARCH="$ARCH" 
     - docker push crosscloudci/k8s-dns-node-cache-"$ARCH:$(git describe --tags --always --dirty)"
     - echo export DNS_NODE_CACHE_IMAGE="$KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,11 +65,16 @@ compile:
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
       fi
     - >
-      echo "kube_version: $RELEASE" >> kubespray.env && \
-      echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env && \
-      echo "hyperkube_checksums:" >> kubespray.env && \
-      echo "  $ARCH:" >> kubespray.env && \
-      echo "  $ARCH:" >> kubespray.env && \
+      echo "kube_version: $RELEASE" >> kubespray.env
+    - >
+      echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
+    - >
+      echo "hyperkube_checksums:" >> kubespray.env
+    - >
+      echo "  $ARCH:" >> kubespray.env
+    - >
+      echo "  $ARCH:" >> kubespray.env
+    - >
       echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
 
   artifacts:
@@ -167,7 +172,8 @@ container:
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
     - >
-      echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env && \
+      echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
+    - >
       echo "kube_image_version: $KUBE_DOCKER_IMAGE_TAG" >> kubespray.env 
     - cat release.env
     - cat kubespray.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,11 +65,11 @@ compile:
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
       fi
     - >
-      echo "kube_version: $RELEASE" >> kubespray.env
-      echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
-      echo "hyperkube_checksums:" >> kubespray.env
-      echo "  $ARCH:" >> kubespray.env
-      echo "  $ARCH:" >> kubespray.env
+      echo "kube_version: $RELEASE" >> kubespray.env && \
+      echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env && \
+      echo "hyperkube_checksums:" >> kubespray.env && \
+      echo "  $ARCH:" >> kubespray.env && \
+      echo "  $ARCH:" >> kubespray.env && \
       echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
 
   artifacts:
@@ -167,7 +167,7 @@ container:
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
     - >
-      echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
+      echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env && \
       echo "kube_image_version: $KUBE_DOCKER_IMAGE_TAG" >> kubespray.env 
     - cat release.env
     - cat kubespray.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,61 +20,70 @@ before_script:
     else
       export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi
-  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard
+  - >
+    if [ -z "$PIPELINE_RELEASE_TYPE" ]; then
+       echo "Kubernetes pipeline must be created by the trigger client, exiting."
+       exit 1
+    else
+       source /opt/local/.env ; ./bin/update_dashboard ; popd
+    fi
+  - ./bin/update_dashboard ; popd
 
 compile:
   image: crosscloudci/debian-docker
   stage: Build
   script:
-    - apt update
-    - apt install -y tar rsync git curl make file net-tools
-    # Write build script
-    - echo '#!/bin/bash' > kubernetes.sh
-    - echo 'set -o errexit' >> kubernetes.sh
-    - echo 'set -o nounset' >> kubernetes.sh
-    - echo 'set -o pipefail' >> kubernetes.sh
-    - echo 'source build/common.sh' >> kubernetes.sh
-    - echo 'source build/lib/release.sh' >> kubernetes.sh
-    - echo 'kube::build::verify_prereqs' >> kubernetes.sh
-    - echo 'kube::build::build_image' >> kubernetes.sh
-    - >
-      if [ "$ARCH" == "arm64" ]; then
-        echo 'ARCH set to arm64'
-        echo 'kube::build::run_build_command make all KUBE_BUILD_PLATFORMS=linux/arm64' >> kubernetes.sh
-        echo 'kube::build::copy_output' >> kubernetes.sh
-      else
-        echo 'Default to amd64 (Intel)'
-        echo 'kube::build::run_build_command make all KUBE_BUILD_PLATFORMS=linux/amd64' >> kubernetes.sh
-        echo 'kube::build::copy_output' >> kubernetes.sh
-      fi
-    #Run Build
-    - chmod +x ./kubernetes.sh 
-    - ./kubernetes.sh
-    - >
-      if [ "$ARCH" == "arm64" ]; then
-        echo 'ARCH set to arm64'
-        echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kubelet >> release.env
-        echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-apiserver >> release.env
-        echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-controller-manager >> release.env
-        echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-scheduler >> release.env
-      else
-        echo 'Default to amd64 (Intel)'
-        echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kubelet >> release.env
-        echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-apiserver >> release.env
-        echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-controller-manager >> release.env
-        echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
-      fi
-    - >
-      echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
+    - echo ' Dummy job for K8s compile'
+    # - apt update
+    # - apt install -y tar rsync git curl make file net-tools
+    # # Write build script
+    # - echo '#!/bin/bash' > kubernetes.sh
+    # - echo 'set -o errexit' >> kubernetes.sh
+    # - echo 'set -o nounset' >> kubernetes.sh
+    # - echo 'set -o pipefail' >> kubernetes.sh
+    # - echo 'source build/common.sh' >> kubernetes.sh
+    # - echo 'source build/lib/release.sh' >> kubernetes.sh
+    # - echo 'kube::build::verify_prereqs' >> kubernetes.sh
+    # - echo 'kube::build::build_image' >> kubernetes.sh
+    # - >
+    #   if [ "$ARCH" == "arm64" ]; then
+    #     echo 'ARCH set to arm64'
+    #     echo 'kube::build::run_build_command make all KUBE_BUILD_PLATFORMS=linux/arm64' >> kubernetes.sh
+    #     echo 'kube::build::copy_output' >> kubernetes.sh
+    #   else
+    #     echo 'Default to amd64 (Intel)'
+    #     echo 'kube::build::run_build_command make all KUBE_BUILD_PLATFORMS=linux/amd64' >> kubernetes.sh
+    #     echo 'kube::build::copy_output' >> kubernetes.sh
+    #   fi
+    # #Run Build
+    # - chmod +x ./kubernetes.sh 
+    # - ./kubernetes.sh
+    # - >
+    #   if [ "$ARCH" == "arm64" ]; then
+    #     echo 'ARCH set to arm64'
+    #     echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kubelet >> release.env
+    #     echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-apiserver >> release.env
+    #     echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-controller-manager >> release.env
+    #     echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/arm64/kube-scheduler >> release.env
+    #   else
+    #     echo 'Default to amd64 (Intel)'
+    #     echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kubelet >> release.env
+    #     echo export KUBE_APISERVER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-apiserver >> release.env
+    #     echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-controller-manager >> release.env
+    #     echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
+    #   fi
+    # - >
+    #   echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
 
-  artifacts:
-    name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
-    when: always
-    expire_in: 1 weeks
-    paths:
-      - release.env
-      - kubespray.env
-      - _output/dockerized/bin/linux/
+  # artifacts:
+  #   name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
+  #   when: always
+  #   expire_in: 1 weeks
+  #   paths:
+  #     - release.env
+  #     - kubespray.env
+  #     - _output/dockerized/bin/linux/
 
 container:
   image: crosscloudci/debian-docker
@@ -82,120 +91,121 @@ container:
   dependencies: 
     - compile
   script:
-    - apt update
-    - apt install -y tar rsync git curl make file net-tools xz-utils
-    # Set Kubespray Release
-    - RELEASE_STABLE="v1.15.0"
-    # Determine actual release
-    - RELEASE="$(git describe --tags --always --dirty | cut -f1 -d"-")"
-    - export KUBE_DOCKER_REGISTRY="$DOCKER_REGISTRY"
-    - export KUBE_DOCKER_IMAGE_TAG="${RELEASE}-${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
-    - echo "${KUBE_DOCKER_IMAGE_TAG}"
-    - mkdir ~/.docker && echo "$DOCKER_AUTH" > ~/.docker/config.json
-    # Write package script
-    - echo '#!/bin/bash' > kubernetes.sh
-    - echo 'set -o errexit' >> kubernetes.sh
-    - echo 'set -o nounset' >> kubernetes.sh
-    - echo 'set -o pipefail' >> kubernetes.sh
-    - >
-      if [ "$ARCH" == "arm64" ]; then
-         echo 'ARCH set to arm64'
-         echo "sed -i -e '/ linux\/arm$/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ linux\/amd64/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ linux\/386/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ linux\/ppc64le/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ darwin\/amd64/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ darwin\/386/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ windows\/386/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-         echo "sed -i -e '/ windows\/amd64/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
-      else
-         echo 'Default to amd64 (Intel)'
-         sed -i -e '/ linux\/arm/ s/^/#/' hack/lib/golang.sh
-         sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh
-         sed -i -e '/ linux\/386/ s/^/#/' hack/lib/golang.sh
-         sed -i -e '/ linux\/ppc64le/ s/^/#/' hack/lib/golang.sh
-         sed -i -e '/ darwin\/amd64/ s/^/#/' hack/lib/golang.sh
-         sed -i -e '/ darwin\/386/ s/^/#/' hack/lib/golang.sh
-         sed -i -e '/ windows\/386/ s/^/#/' hack/lib/golang.sh
-         sed -i -e '/ windows\/amd64/ s/^/#/' hack/lib/golang.sh
-      fi
-    - echo 'source build/common.sh' >> kubernetes.sh
-    - echo 'source build/lib/release.sh' >> kubernetes.sh
-    - echo 'kube::build::verify_prereqs' >> kubernetes.sh
-    - echo 'kube::release::build_server_images' >> kubernetes.sh
-    # Run Package 
-    - chmod +x ./kubernetes.sh
-    - ./kubernetes.sh
-    - docker tag "$KUBE_DOCKER_REGISTRY/kube-apiserver-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-apiserver:$KUBE_DOCKER_IMAGE_TAG"
-    - docker tag "$KUBE_DOCKER_REGISTRY/kube-controller-manager-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-controller-manager:$KUBE_DOCKER_IMAGE_TAG" 
-    - docker tag "$KUBE_DOCKER_REGISTRY/kube-scheduler-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-scheduler:$KUBE_DOCKER_IMAGE_TAG"
-    - docker tag "$KUBE_DOCKER_REGISTRY/kube-proxy-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
-    - docker push "$KUBE_DOCKER_REGISTRY/kube-apiserver:$KUBE_DOCKER_IMAGE_TAG"
-    - docker push "$KUBE_DOCKER_REGISTRY/kube-controller-manager:$KUBE_DOCKER_IMAGE_TAG"
-    - docker push "$KUBE_DOCKER_REGISTRY/kube-scheduler:$KUBE_DOCKER_IMAGE_TAG"
-    - docker push "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
-    #Publish pause image
-    - make -C ./build/pause/ all-push REGISTRY="${KUBE_DOCKER_REGISTRY}"
-    #Push dummy coredns image
-    - docker pull coredns/coredns:1.2.6
-    - docker tag coredns/coredns:1.2.6 crosscloudci/coredns:1.2.6
-    - docker push crosscloudci/coredns:1.2.6
-    - docker pull coredns/coredns:1.3.1
-    - docker tag coredns/coredns:1.3.1 crosscloudci/coredns:1.3.1
-    - docker push crosscloudci/coredns:1.3.1
-    #Enable binfmt_misc 
-    - >
-      if [ "$ARCH" == "arm64" ]; then
-        echo 'ARCH set to arm64'
-        docker run --privileged linuxkit/binfmt:v0.6
-      fi
-    #Publish k8s-dns-node-cache/arm64 image
-    - git clone https://github.com/kubernetes/dns.git
-    - cd dns
-    - sed -i "15s|.*|FROM ARG_FROM|" ./Dockerfile.node-cache
-    - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" ARCH="$ARCH" 
-    - docker push crosscloudci/k8s-dns-node-cache-"$ARCH:$(git describe --tags --always --dirty)"
-    - DNS_GIT_VERSION="$(git describe --tags --always --dirty)"
-    - cd -
-    - echo export DNS_NODE_CACHE_IMAGE="$KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> release.env
-    - echo export DNS_NODE_CACHE_TAG="$DNS_GIT_VERSION" >> release.env
-    - >
-      echo "nodelocaldns_image_repo: $KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> kubespray.env
-    - >
-      echo "nodelocaldns_image_tag: $DNS_GIT_VERSION" >> kubespray.env
-    - echo export KUBERNETES_VERSION="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export KUBE_APISERVER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-apiserver" >> release.env
-    - echo export KUBE_APISERVER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export KUBE_CONTROLLER_MANAGER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-controller-manager" >> release.env
-    - echo export KUBE_CONTROLLER_MANAGER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export KUBE_SCHEDULER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-scheduler" >> release.env
-    - echo export KUBE_SCHEDULER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export KUBE_PROXY_IMAGE="$KUBE_DOCKER_REGISTRY/kube-proxy" >> release.env
-    - echo export KUBE_PROXY_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
-    - echo export KUBERNETES_SHA="${CI_COMMIT_SHA}" >> release.env
-    - >
-      echo "hyperkube_checksums:" >> kubespray.env
-    - >
-      echo "  $ARCH:" >> kubespray.env
-    - >
-      echo "    $RELEASE_STABLE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube | awk '{ print $1 }')" >> kubespray.env
-    - >
-      echo "kube_version: $RELEASE_STABLE" >> kubespray.env
-    - >
-      echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
-    - >
-      echo "kube_image_version: $KUBE_DOCKER_IMAGE_TAG" >> kubespray.env 
-    - cat release.env
-    - cat kubespray.env
-  artifacts:
-    name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
-    when: always
-    expire_in: 1 weeks
-    paths:
-      - release.env
-      - kubespray.env
+    - echo ' Dummy job for K8s container'
+  #   - apt update
+  #   - apt install -y tar rsync git curl make file net-tools xz-utils
+  #   # Set Kubespray Release
+  #   - RELEASE_STABLE="v1.15.0"
+  #   # Determine actual release
+  #   - RELEASE="$(git describe --tags --always --dirty | cut -f1 -d"-")"
+  #   - export KUBE_DOCKER_REGISTRY="$DOCKER_REGISTRY"
+  #   - export KUBE_DOCKER_IMAGE_TAG="${RELEASE}-${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${ARCH}"
+  #   - echo "${KUBE_DOCKER_IMAGE_TAG}"
+  #   - mkdir ~/.docker && echo "$DOCKER_AUTH" > ~/.docker/config.json
+  #   # Write package script
+  #   - echo '#!/bin/bash' > kubernetes.sh
+  #   - echo 'set -o errexit' >> kubernetes.sh
+  #   - echo 'set -o nounset' >> kubernetes.sh
+  #   - echo 'set -o pipefail' >> kubernetes.sh
+  #   - >
+  #     if [ "$ARCH" == "arm64" ]; then
+  #        echo 'ARCH set to arm64'
+  #        echo "sed -i -e '/ linux\/arm$/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ linux\/amd64/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ linux\/386/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ linux\/ppc64le/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ darwin\/amd64/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ darwin\/386/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ windows\/386/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #        echo "sed -i -e '/ windows\/amd64/ s/^/#/' hack/lib/golang.sh" >> kubernetes.sh
+  #     else
+  #        echo 'Default to amd64 (Intel)'
+  #        sed -i -e '/ linux\/arm/ s/^/#/' hack/lib/golang.sh
+  #        sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh
+  #        sed -i -e '/ linux\/386/ s/^/#/' hack/lib/golang.sh
+  #        sed -i -e '/ linux\/ppc64le/ s/^/#/' hack/lib/golang.sh
+  #        sed -i -e '/ darwin\/amd64/ s/^/#/' hack/lib/golang.sh
+  #        sed -i -e '/ darwin\/386/ s/^/#/' hack/lib/golang.sh
+  #        sed -i -e '/ windows\/386/ s/^/#/' hack/lib/golang.sh
+  #        sed -i -e '/ windows\/amd64/ s/^/#/' hack/lib/golang.sh
+  #     fi
+  #   - echo 'source build/common.sh' >> kubernetes.sh
+  #   - echo 'source build/lib/release.sh' >> kubernetes.sh
+  #   - echo 'kube::build::verify_prereqs' >> kubernetes.sh
+  #   - echo 'kube::release::build_server_images' >> kubernetes.sh
+  #   # Run Package 
+  #   - chmod +x ./kubernetes.sh
+  #   - ./kubernetes.sh
+  #   - docker tag "$KUBE_DOCKER_REGISTRY/kube-apiserver-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-apiserver:$KUBE_DOCKER_IMAGE_TAG"
+  #   - docker tag "$KUBE_DOCKER_REGISTRY/kube-controller-manager-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-controller-manager:$KUBE_DOCKER_IMAGE_TAG" 
+  #   - docker tag "$KUBE_DOCKER_REGISTRY/kube-scheduler-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-scheduler:$KUBE_DOCKER_IMAGE_TAG"
+  #   - docker tag "$KUBE_DOCKER_REGISTRY/kube-proxy-$ARCH:$KUBE_DOCKER_IMAGE_TAG" "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
+  #   - docker push "$KUBE_DOCKER_REGISTRY/kube-apiserver:$KUBE_DOCKER_IMAGE_TAG"
+  #   - docker push "$KUBE_DOCKER_REGISTRY/kube-controller-manager:$KUBE_DOCKER_IMAGE_TAG"
+  #   - docker push "$KUBE_DOCKER_REGISTRY/kube-scheduler:$KUBE_DOCKER_IMAGE_TAG"
+  #   - docker push "$KUBE_DOCKER_REGISTRY/kube-proxy:$KUBE_DOCKER_IMAGE_TAG"
+  #   #Publish pause image
+  #   - make -C ./build/pause/ all-push REGISTRY="${KUBE_DOCKER_REGISTRY}"
+  #   #Push dummy coredns image
+  #   - docker pull coredns/coredns:1.2.6
+  #   - docker tag coredns/coredns:1.2.6 crosscloudci/coredns:1.2.6
+  #   - docker push crosscloudci/coredns:1.2.6
+  #   - docker pull coredns/coredns:1.3.1
+  #   - docker tag coredns/coredns:1.3.1 crosscloudci/coredns:1.3.1
+  #   - docker push crosscloudci/coredns:1.3.1
+  #   #Enable binfmt_misc 
+  #   - >
+  #     if [ "$ARCH" == "arm64" ]; then
+  #       echo 'ARCH set to arm64'
+  #       docker run --privileged linuxkit/binfmt:v0.6
+  #     fi
+  #   #Publish k8s-dns-node-cache/arm64 image
+  #   - git clone https://github.com/kubernetes/dns.git
+  #   - cd dns
+  #   - sed -i "15s|.*|FROM ARG_FROM|" ./Dockerfile.node-cache
+  #   - make containers CONTAINER_BINARIES=node-cache REGISTRY="$KUBE_DOCKER_REGISTRY" ARCH="$ARCH" 
+  #   - docker push crosscloudci/k8s-dns-node-cache-"$ARCH:$(git describe --tags --always --dirty)"
+  #   - DNS_GIT_VERSION="$(git describe --tags --always --dirty)"
+  #   - cd -
+  #   - echo export DNS_NODE_CACHE_IMAGE="$KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> release.env
+  #   - echo export DNS_NODE_CACHE_TAG="$DNS_GIT_VERSION" >> release.env
+  #   - >
+  #     echo "nodelocaldns_image_repo: $KUBE_DOCKER_REGISTRY/k8s-dns-node-cache-$ARCH" >> kubespray.env
+  #   - >
+  #     echo "nodelocaldns_image_tag: $DNS_GIT_VERSION" >> kubespray.env
+  #   - echo export KUBERNETES_VERSION="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+  #   - echo export KUBE_APISERVER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-apiserver" >> release.env
+  #   - echo export KUBE_APISERVER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+  #   - echo export KUBE_CONTROLLER_MANAGER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-controller-manager" >> release.env
+  #   - echo export KUBE_CONTROLLER_MANAGER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+  #   - echo export KUBE_SCHEDULER_IMAGE="$KUBE_DOCKER_REGISTRY/kube-scheduler" >> release.env
+  #   - echo export KUBE_SCHEDULER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+  #   - echo export KUBE_PROXY_IMAGE="$KUBE_DOCKER_REGISTRY/kube-proxy" >> release.env
+  #   - echo export KUBE_PROXY_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+  #   - echo export DEPLOYMENT_SHA="${CI_PIPELINE_ID}" >> release.env
+  #   - echo export KUBERNETES_SHA="${CI_COMMIT_SHA}" >> release.env
+  #   - >
+  #     echo "hyperkube_checksums:" >> kubespray.env
+  #   - >
+  #     echo "  $ARCH:" >> kubespray.env
+  #   - >
+  #     echo "    $RELEASE_STABLE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube | awk '{ print $1 }')" >> kubespray.env
+  #   - >
+  #     echo "kube_version: $RELEASE_STABLE" >> kubespray.env
+  #   - >
+  #     echo "kube_image_repo: $KUBE_DOCKER_REGISTRY" >> kubespray.env
+  #   - >
+  #     echo "kube_image_version: $KUBE_DOCKER_IMAGE_TAG" >> kubespray.env 
+  #   - cat release.env
+  #   - cat kubespray.env
+  # artifacts:
+  #   name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
+  #   when: always
+  #   expire_in: 1 weeks
+  #   paths:
+  #     - release.env
+  #     - kubespray.env
 
 Dashboard:
   image: crosscloudci/debian-go

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,14 +64,13 @@ compile:
         echo export KUBE_CONTROLLER_MANAGER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-controller-manager >> release.env
         echo export KUBE_SCHEDULER_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/_output/dockerized/bin/linux/amd64/kube-scheduler >> release.env
       fi
-    - echo "kube_version: $RELEASE" >> kubespray.env
-    - echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
-    - echo "hyperkube_checksums:" >> kubespray.env
-    - echo "  $ARCH:" >> kubespray.env
-    - echo "  $ARCH:" >> kubespray.env
-    - echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
+    # - echo "kube_version: $RELEASE" >> kubespray.env
+    # - echo "hyperkube_download_url: $BASE_URL/kubernetes/kubernetes/-/jobs/$CI_JOB_ID/artifacts/raw/_output/dockerized/bin/linux/$ARCH/hyperkube" >> kubespray.env
+    # - echo "hyperkube_checksums:" >> kubespray.env
+    # - echo "  $ARCH:" >> kubespray.env
+    # - echo "  $ARCH:" >> kubespray.env
+    # - echo "      $RELEASE: $(sha256sum _output/dockerized/bin/linux/$ARCH/hyperkube)" >> kubespray.env
 
-    
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ before_script:
     else
       export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi
-  # - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
   image: crosscloudci/debian-docker

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v1.13.0"
+  stable_ref: "v1.16.2"
   head_ref: "master"


### PR DESCRIPTION
## Description

Switching to artifacts from K8s SIG Testing.

Disabling custom builds in Gitlab

Only run if pipeline trigger client requested start.

issues:
- crosscloudci/crosscloudci#181
- vulk/cncf_ci#265


## Motivation and Context




## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.