### PR TITLE
Promoting to prod: switching to upstream artifacts for K8s

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,7 +88,7 @@ container:
     - echo export KUBE_AGGREGATOR_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export CLOUD_CONTROLLER_IMAGE="$CI_REGISTRY_IMAGE/cloud-controller-manager-amd64" >> release.env
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}-${CI_COMMIT_SHA_SHORT}" >> release.env
+    - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID} >> release.env
     - cat release.env
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,11 +18,11 @@ before_script:
   - export CI_COMMIT_SHA_SHORT=$(echo ${CI_COMMIT_SHA} | cut -c -8)
   - >
     if [ -z "$CROSS_CLOUD_YML" ]; then
-       if [ "BASE_URL" == "https://gitlab.cncf.ci" ]; then
+       if [ "$BASE_URL" == "https://gitlab.cncf.ci" ]; then
           export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/production/cross-cloud.yml"
-       elif [ "BASE_URL" == "https://gitlab.staging.cncf.ci" ]; then
+       elif [ "$BASE_URL" == "https://gitlab.staging.cncf.ci" ]; then
           export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/staging/cross-cloud.yml"
-       elif [ "BASE_URL" == "https://gitlab.cidev.cncf.ci" ]; then
+       elif [ "$BASE_URL" == "https://gitlab.cidev.cncf.ci" ]; then
           export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/integration/cross-cloud.yml"
        else
           export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/master/cross-cloud.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,15 @@ before_script:
   - export CI_COMMIT_SHA_SHORT=$(echo ${CI_COMMIT_SHA} | cut -c -8)
   - >
     if [ -z "$CROSS_CLOUD_YML" ]; then
-      export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/production/cross-cloud.yml"
+       if [ "BASE_URL" == "https://gitlab.cncf.ci" ]; then
+          export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/production/cross-cloud.yml"
+       elif [ "BASE_URL" == "https://gitlab.staging.cncf.ci" ]; then
+          export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/staging/cross-cloud.yml"
+       elif [ "BASE_URL" == "https://gitlab.cidev.cncf.ci" ]; then
+          export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/integration/cross-cloud.yml"
+       else
+          export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/master/cross-cloud.yml"
+       fi
     else
       export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,8 @@ compile:
 container:
   image: crosscloudci/debian-docker
   stage: Package
+  dependencies: 
+    - compile
   script:
     - export KUBE_DOCKER_REGISTRY="${CI_REGISTRY_IMAGE}"
     - export KUBE_DOCKER_IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,11 +17,10 @@ before_script:
   - export BASE_URL=${BASE_URL:-$(echo $CI_PROJECT_URL |  cut -d'/' -f1-3)}
   - export CI_COMMIT_SHA_SHORT=$(echo ${CI_COMMIT_SHA} | cut -c -8)
   - >
-    if [ "$BASE_URL" == "https://gitlab.dev.cncf.ci" ]; then
-      export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/master/cross-cloud.yml"
+    if [ -z "$CROSS_CLOUD_YML" ]; then
+      export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/production/cross-cloud.yml"
     else
-      echo "Environment doesn't match"
-      exit 0
+      export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi
   - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,8 @@ compile:
     KUBE_FASTBUILD: "false"
     KUBE_VERBOSE: "0"
     FEDERATION: "false"
-    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA}"
+    KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
+    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
   script:
     - apt update
     - apt install -y tar rsync git curl make file
@@ -40,6 +41,8 @@ compile:
     - ./build/release.sh
     - cp -a _output/dockerized/bin/linux/amd64 linux-amd64
     - echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/linux-amd64/kubelet >> release.env
+    - cat release.env
+    - docker images
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
     when: always
@@ -53,7 +56,7 @@ container:
   stage: Package
   variables:
     KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
-    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA}"
+    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
   script:
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
     - docker images | grep kubernetes/kubernetes

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 stages:
   - Build
   - Package
-  # - Cross-Cloud
   - Update-Dashboard
 
 before_script:
@@ -33,24 +32,14 @@ compile:
     KUBE_FASTBUILD: "false"
     KUBE_VERBOSE: "0"
     FEDERATION: "false"
-    KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
-    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"
-    #.${CI_PIPELINE_ID}.${CI_COMMIT_SHA}"
+    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA}"
   script:
     - apt update
     - apt install -y tar rsync git curl make file
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
     - ./build/release.sh
     - cp -a _output/dockerized/bin/linux/amd64 linux-amd64
-    - >
-      if [ "$CI_COMMIT_REF_NAME" == "v1.8.1" ]; then
-        echo export KUBELET_ARTIFACT=https://storage.googleapis.com/kubernetes-release/release/v1.8.1/bin/linux/amd64/kubelet >> release.env
-      elif [ "$CI_COMMIT_REF_NAME" == "master" ]; then
-        echo export KUBELET_ARTIFACT=https://storage.googleapis.com/kubernetes-release/release/v1.9.0-beta.1/bin/linux/amd64/kubelet >> release.env
-      else
-        echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/linux-amd64/kubelet >> release.env
-      fi
-    - cat release.env
+    - echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/linux-amd64/kubelet >> release.env
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
     when: always
@@ -64,8 +53,7 @@ container:
   stage: Package
   variables:
     KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
-    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"
-    # .${CI_PIPELINE_ID}.${CI_COMMIT_SHA}
+    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA}"
   script:
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
     - docker images | grep kubernetes/kubernetes
@@ -88,8 +76,7 @@ container:
     - echo export KUBE_AGGREGATOR_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export CLOUD_CONTROLLER_IMAGE="$CI_REGISTRY_IMAGE/cloud-controller-manager-amd64" >> release.env
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    # - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}-${CI_COMMIT_SHA_SHORT}" >> release.env
-    - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}" >> release.env
+    - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}-${CI_COMMIT_SHA_SHORT}" >> release.env
     - cat release.env
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
@@ -98,57 +85,8 @@ container:
     paths:
       - release.env
 
-# Deploy Template used for Cross-Cloud API Call
-.cross-cloud: &cross-cloud
-  allow_failure: false
-  image: buildpack-deps:stretch
-  stage: Cross-Cloud
-  # variables:
-  #   KUBERNETES_BRANCH: MUST BE SET
-  #   CLOUD: MUST BE SET
-  script:
-    - >
-      if [ "$BUILD_TRIGGER" == "yes" ]; then
-        exit 0
-      else
-        apt update && apt install -y jq
-        PROJECT_PIPELINE=$(curl -X POST -F token=$CROSS_CLOUD_CI_JOB_TOKEN -F ref=v2.0.0-beta -F "variables[BRANCH]="${CLOUD_BRANCH}"" -F "variables[COMMIT]="${CLOUD_COMMIT}"" -F "variables[SOURCE]="${CI_PIPELINE_ID}"" -F "variables[DISABLE_SOURCE]="${CLOUD_DISABLE_SOURCE}"" -F "variables[ORG]=kubernetes" -F "variables[PROJECT]=kubernetes" -F "variables[PROJECT_ID]=14" -F "variables[PROJECT_TOKEN]="${KUBERNETES_PROJECT_TOKEN}"" -F "variables[CLOUD]="${CLOUD}"" -F "variables[TARGET_PROJECT_NAME]="${CI_PROJECT_NAME}"" -F "variables[TARGET_PROJECT_COMMIT_REF_NAME]="${CI_COMMIT_REF_NAME}"" -F "variables[PROJECT_BUILD_PIPELINE_ID]="${CI_PIPELINE_ID}"" -F "variables[GITLAB_USER_EMAIL]="${GITLAB_USER_EMAIL}"" "$BASE_URL"/api/v4/projects/2/trigger/pipeline | jq '.id')
-        # PROJECT_PIPELINE=$(curl -X POST -F token=$CI_JOB_TOKEN -F ref=stable-v0.2.0-integrations https://gitlab.cncf.ci/api/v4/projects/2/trigger/pipeline | jq '.id')
-
-        echo 'Wait for Cluster "FIX ME / HACK"'
-        until [ "$JOB_STATUS" == '"success"' ]; do
-            JOB_STATUS="$(curl -s --header "PRIVATE-TOKEN:${TOKEN}" "${BASE_URL}/api/v4/projects/2/pipelines/${PROJECT_PIPELINE}/jobs" | jq '.[] | select(.name=="Provisioning") | .status')"
-            sleep 0.5
-            if [ "$JOB_STATUS" == '"failed"' ]; then
-                exit 1
-            elif [ "$JOB_STATUS" == '"canceled"' ]; then
-                exit 1
-            elif [ "$JOB_STATUS" == '"skipped"' ]; then
-                exit 1
-            else
-                continue
-            fi
-        done
-        echo 'Cluster Ready'
-
-
-        PROJECT_JOB=$(curl --header "PRIVATE-TOKEN:${TOKEN}" "${BASE_URL}/api/v4/projects/2/pipelines/${PROJECT_PIPELINE}/jobs?scope=success" | jq '.[] | select(.name=="Provisioning") | .id')
-        export BASE_URL=${BASE_URL:-$(echo $CI_PROJECT_URL |  cut -d'/' -f1-3)}
-        curl -s -o kubeconfig -L "$BASE_URL/cncf/cross-cloud/-/jobs/${PROJECT_JOB}/artifacts/raw/data/$CLOUD/kubeconfig"
-        cat ./kubeconfig | base64 | tee ./kubeconfig
-
-      fi
-  artifacts:
-    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
-    expire_in: 5 weeks
-    paths:
-      - kubeconfig
-
 Dashboard:
-  image: registry.cncf.ci/cncf/cross-cloud:go
+  image: crosscloudci/debian-go
   stage: Update-Dashboard
   script:
     - echo 'test'
-
-# Cross-Cloud:
-#   <<: *cross-cloud

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,7 +88,7 @@ container:
     - echo export KUBE_AGGREGATOR_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
     - echo export CLOUD_CONTROLLER_IMAGE="$CI_REGISTRY_IMAGE/cloud-controller-manager-amd64" >> release.env
     - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
-    - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID} >> release.env
+    - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}" >> release.env
     - cat release.env
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 
 before_script:
   - echo "Remove old Docker Images"
-  - docker rmi $(docker images)
+  - docker rmi $(docker images) || true
   - echo "We are only going to build for amd64 for this demo"
   - sed -i -e '/ linux\/arm/ s/^/#/' hack/lib/golang.sh
   - sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,9 +32,9 @@ compile:
     KUBE_FASTBUILD: "false"
     KUBE_VERBOSE: "0"
     FEDERATION: "false"
-    KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
-    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
   script:
+    - export KUBE_DOCKER_REGISTRY="${CI_REGISTRY_IMAGE}"
+    - export KUBE_DOCKER_IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
     - apt update
     - apt install -y tar rsync git curl make file
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
@@ -42,7 +42,6 @@ compile:
     - cp -a _output/dockerized/bin/linux/amd64 linux-amd64
     - echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/linux-amd64/kubelet >> release.env
     - cat release.env
-    - docker images
   artifacts:
     name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
     when: always
@@ -54,12 +53,10 @@ compile:
 container:
   image: crosscloudci/debian-docker
   stage: Package
-  variables:
-    KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
-    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
   script:
+    - export KUBE_DOCKER_REGISTRY="${CI_REGISTRY_IMAGE}"
+    - export KUBE_DOCKER_IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
-    - docker images | grep kubernetes/kubernetes
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker push "$CI_REGISTRY_IMAGE/kube-apiserver-amd64:$KUBE_DOCKER_IMAGE_TAG"
     - docker push "$CI_REGISTRY_IMAGE/kube-controller-manager-amd64:$KUBE_DOCKER_IMAGE_TAG"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ compile:
     - export KUBE_DOCKER_REGISTRY="${CI_REGISTRY_IMAGE}"
     - export KUBE_DOCKER_IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
     - apt update
-    - apt install -y tar rsync git curl make file
+    - apt install -y tar rsync git curl make file ifconfig
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
     - ./build/release.sh
     - cp -a _output/dockerized/bin/linux/amd64 linux-amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,155 @@
+stages:
+  - Build
+  - Package
+  # - Cross-Cloud
+  - Update-Dashboard
+
+before_script:
+  - echo "We are only going to build for amd64 for this demo"
+  - sed -i -e '/ linux\/arm/ s/^/#/' hack/lib/golang.sh
+  - sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh
+  - sed -i -e '/ linux\/386/ s/^/#/' hack/lib/golang.sh
+  - sed -i -e '/ linux\/ppc64le/ s/^/#/' hack/lib/golang.sh
+  - sed -i -e '/ darwin\/amd64/ s/^/#/' hack/lib/golang.sh
+  - sed -i -e '/ darwin\/386/ s/^/#/' hack/lib/golang.sh
+  - sed -i -e '/ windows\/386/ s/^/#/' hack/lib/golang.sh
+  - sed -i -e '/ windows\/amd64/ s/^/#/' hack/lib/golang.sh
+  - export BASE_URL=${BASE_URL:-$(echo $CI_PROJECT_URL |  cut -d'/' -f1-3)}
+  - export CI_COMMIT_SHA_SHORT=$(echo ${CI_COMMIT_SHA} | cut -c -8)
+  - >
+    if [ "$BASE_URL" == "https://gitlab.dev.cncf.ci" ]; then
+      export CROSS_CLOUD_YML="https://raw.githubusercontent.com/CrossCloudCI/cncf-configuration/master/cross-cloud.yml"
+    else
+      echo "Environment doesn't match"
+      exit 0
+    fi
+  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+
+
+compile:
+  image: crosscloudci/debian-docker
+  stage: Build
+  variables:
+    KUBE_RELEASE_RUN_TESTS: "n"
+    KUBE_FASTBUILD: "false"
+    KUBE_VERBOSE: "0"
+    FEDERATION: "false"
+    KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
+    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"
+    #.${CI_PIPELINE_ID}.${CI_COMMIT_SHA}"
+  script:
+    - apt update
+    - apt install -y tar rsync git curl make file
+    - echo "${KUBE_DOCKER_IMAGE_TAG}"
+    - ./build/release.sh
+    - cp -a _output/dockerized/bin/linux/amd64 linux-amd64
+    - >
+      if [ "$CI_COMMIT_REF_NAME" == "v1.8.1" ]; then
+        echo export KUBELET_ARTIFACT=https://storage.googleapis.com/kubernetes-release/release/v1.8.1/bin/linux/amd64/kubelet >> release.env
+      elif [ "$CI_COMMIT_REF_NAME" == "master" ]; then
+        echo export KUBELET_ARTIFACT=https://storage.googleapis.com/kubernetes-release/release/v1.9.0-beta.1/bin/linux/amd64/kubelet >> release.env
+      else
+        echo export KUBELET_ARTIFACT="$BASE_URL"/kubernetes/kubernetes/-/jobs/${CI_JOB_ID}/artifacts/raw/linux-amd64/kubelet >> release.env
+      fi
+    - cat release.env
+  artifacts:
+    name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
+    when: always
+    expire_in: 1 weeks
+    paths:
+      - release.env
+      - linux-amd64
+
+container:
+  image: crosscloudci/debian-docker
+  stage: Package
+  variables:
+    KUBE_DOCKER_REGISTRY: "${CI_REGISTRY_IMAGE}"
+    KUBE_DOCKER_IMAGE_TAG: "${CI_COMMIT_REF_SLUG}"
+    # .${CI_PIPELINE_ID}.${CI_COMMIT_SHA}
+  script:
+    - echo "${KUBE_DOCKER_IMAGE_TAG}"
+    - docker images | grep kubernetes/kubernetes
+    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+    - docker push "$CI_REGISTRY_IMAGE/kube-apiserver-amd64:$KUBE_DOCKER_IMAGE_TAG"
+    - docker push "$CI_REGISTRY_IMAGE/kube-controller-manager-amd64:$KUBE_DOCKER_IMAGE_TAG"
+    - docker push "$CI_REGISTRY_IMAGE/kube-scheduler-amd64:$KUBE_DOCKER_IMAGE_TAG"
+    - docker push "$CI_REGISTRY_IMAGE/kube-proxy-amd64:$KUBE_DOCKER_IMAGE_TAG"
+    - docker push "$CI_REGISTRY_IMAGE/kube-aggregator-amd64:$KUBE_DOCKER_IMAGE_TAG"
+    - docker push "$CI_REGISTRY_IMAGE/cloud-controller-manager-amd64:$KUBE_DOCKER_IMAGE_TAG"
+    - echo export KUBE_APISERVER_IMAGE="$CI_REGISTRY_IMAGE/kube-apiserver-amd64" >> release.env
+    - echo export KUBE_APISERVER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+    - echo export KUBE_CONTROLLER_MANAGER_IMAGE="$CI_REGISTRY_IMAGE/kube-controller-manager-amd64" >> release.env
+    - echo export KUBE_CONTROLLER_MANAGER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+    - echo export KUBE_SCHEDULER_IMAGE="$CI_REGISTRY_IMAGE/kube-scheduler-amd64" >> release.env
+    - echo export KUBE_SCHEDULER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+    - echo export KUBE_PROXY_IMAGE="$CI_REGISTRY_IMAGE/kube-proxy-amd64" >> release.env
+    - echo export KUBE_PROXY_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+    - echo export KUBE_AGGREGATOR_IMAGE="$CI_REGISTRY_IMAGE/kube-aggregator-amd64" >> release.env
+    - echo export KUBE_AGGREGATOR_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+    - echo export CLOUD_CONTROLLER_IMAGE="$CI_REGISTRY_IMAGE/cloud-controller-manager-amd64" >> release.env
+    - echo export CLOUD_CONTROLLER_TAG="$KUBE_DOCKER_IMAGE_TAG" >> release.env
+    # - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}-${CI_COMMIT_SHA_SHORT}" >> release.env
+    - echo export DEPLOYMENT_SHA="${CI_COMMIT_REF_SLUG}" >> release.env
+    - cat release.env
+  artifacts:
+    name: "${CI_JOB_NAME}.${CI_PIPELINE_ID}.${CI_JOB_ID}"
+    when: always
+    expire_in: 1 weeks
+    paths:
+      - release.env
+
+# Deploy Template used for Cross-Cloud API Call
+.cross-cloud: &cross-cloud
+  allow_failure: false
+  image: buildpack-deps:stretch
+  stage: Cross-Cloud
+  # variables:
+  #   KUBERNETES_BRANCH: MUST BE SET
+  #   CLOUD: MUST BE SET
+  script:
+    - >
+      if [ "$BUILD_TRIGGER" == "yes" ]; then
+        exit 0
+      else
+        apt update && apt install -y jq
+        PROJECT_PIPELINE=$(curl -X POST -F token=$CROSS_CLOUD_CI_JOB_TOKEN -F ref=v2.0.0-beta -F "variables[BRANCH]="${CLOUD_BRANCH}"" -F "variables[COMMIT]="${CLOUD_COMMIT}"" -F "variables[SOURCE]="${CI_PIPELINE_ID}"" -F "variables[DISABLE_SOURCE]="${CLOUD_DISABLE_SOURCE}"" -F "variables[ORG]=kubernetes" -F "variables[PROJECT]=kubernetes" -F "variables[PROJECT_ID]=14" -F "variables[PROJECT_TOKEN]="${KUBERNETES_PROJECT_TOKEN}"" -F "variables[CLOUD]="${CLOUD}"" -F "variables[TARGET_PROJECT_NAME]="${CI_PROJECT_NAME}"" -F "variables[TARGET_PROJECT_COMMIT_REF_NAME]="${CI_COMMIT_REF_NAME}"" -F "variables[PROJECT_BUILD_PIPELINE_ID]="${CI_PIPELINE_ID}"" -F "variables[GITLAB_USER_EMAIL]="${GITLAB_USER_EMAIL}"" "$BASE_URL"/api/v4/projects/2/trigger/pipeline | jq '.id')
+        # PROJECT_PIPELINE=$(curl -X POST -F token=$CI_JOB_TOKEN -F ref=stable-v0.2.0-integrations https://gitlab.cncf.ci/api/v4/projects/2/trigger/pipeline | jq '.id')
+
+        echo 'Wait for Cluster "FIX ME / HACK"'
+        until [ "$JOB_STATUS" == '"success"' ]; do
+            JOB_STATUS="$(curl -s --header "PRIVATE-TOKEN:${TOKEN}" "${BASE_URL}/api/v4/projects/2/pipelines/${PROJECT_PIPELINE}/jobs" | jq '.[] | select(.name=="Provisioning") | .status')"
+            sleep 0.5
+            if [ "$JOB_STATUS" == '"failed"' ]; then
+                exit 1
+            elif [ "$JOB_STATUS" == '"canceled"' ]; then
+                exit 1
+            elif [ "$JOB_STATUS" == '"skipped"' ]; then
+                exit 1
+            else
+                continue
+            fi
+        done
+        echo 'Cluster Ready'
+
+
+        PROJECT_JOB=$(curl --header "PRIVATE-TOKEN:${TOKEN}" "${BASE_URL}/api/v4/projects/2/pipelines/${PROJECT_PIPELINE}/jobs?scope=success" | jq '.[] | select(.name=="Provisioning") | .id')
+        export BASE_URL=${BASE_URL:-$(echo $CI_PROJECT_URL |  cut -d'/' -f1-3)}
+        curl -s -o kubeconfig -L "$BASE_URL/cncf/cross-cloud/-/jobs/${PROJECT_JOB}/artifacts/raw/data/$CLOUD/kubeconfig"
+        cat ./kubeconfig | base64 | tee ./kubeconfig
+
+      fi
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    expire_in: 5 weeks
+    paths:
+      - kubeconfig
+
+Dashboard:
+  image: registry.cncf.ci/cncf/cross-cloud:go
+  stage: Update-Dashboard
+  script:
+    - echo 'test'
+
+# Cross-Cloud:
+#   <<: *cross-cloud

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,8 @@ stages:
   - Update-Dashboard
 
 before_script:
+  - echo "Remove old Docker Images"
+  - docker rmi $(docker images)
   - echo "We are only going to build for amd64 for this demo"
   - sed -i -e '/ linux\/arm/ s/^/#/' hack/lib/golang.sh
   - sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@ stages:
 
 before_script:
   - echo "Remove old Docker Images"
-  - docker rmi $(docker images) || true
   - echo "We are only going to build for amd64 for this demo"
   - sed -i -e '/ linux\/arm/ s/^/#/' hack/lib/golang.sh
   - sed -i -e '/ linux\/s390/ s/^/#/' hack/lib/golang.sh
@@ -43,6 +42,7 @@ compile:
     KUBE_VERBOSE: "0"
     FEDERATION: "false"
   script:
+    - docker rmi $(docker images) || true
     - export KUBE_DOCKER_REGISTRY="${CI_REGISTRY_IMAGE}"
     - export KUBE_DOCKER_IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
     - apt update

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ compile:
     - export KUBE_DOCKER_REGISTRY="${CI_REGISTRY_IMAGE}"
     - export KUBE_DOCKER_IMAGE_TAG="${CI_COMMIT_REF_SLUG}.${CI_PIPELINE_ID}.${CI_COMMIT_SHA_SHORT}"
     - apt update
-    - apt install -y tar rsync git curl make file ifconfig
+    - apt install -y tar rsync git curl make file net-tools
     - echo "${KUBE_DOCKER_IMAGE_TAG}"
     - ./build/release.sh
     - cp -a _output/dockerized/bin/linux/amd64 linux-amd64

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# kubernetes-configuration


### PR DESCRIPTION
## Description

Switching to artifacts from K8s SIG Testing.

Disabling custom builds in Gitlab

Only run if pipeline trigger client requested start.

issues:
- crosscloudci/crosscloudci#181
- vulk/cncf_ci#265


## Motivation and Context




## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [x] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.